### PR TITLE
Add immediate-mode based sharp font handling

### DIFF
--- a/src/main/java/net/irisshaders/imgui/ImGuiMC.java
+++ b/src/main/java/net/irisshaders/imgui/ImGuiMC.java
@@ -28,6 +28,7 @@ public class ImGuiMC {
     private ImGuiImplGl3 glAccessor;
     private ImGuiImplGlfw glWindow;
     private boolean drawing;
+    private boolean usesSharpFontTexture;
 
     public static ImGuiMC getInstance() {
         return INSTANCE;
@@ -51,6 +52,24 @@ public class ImGuiMC {
         ImGui.setCurrentContext(getInstance().context);
 
         return getInstance().drawing;
+    }
+
+    public boolean usesSharpFont() {
+        return this.usesSharpFontTexture;
+    }
+
+    /**
+     * Enables sharp (nearest) font rendering. Useful for Minecraft-like fonts.
+     */
+    public static void enableSharpFont() {
+        getInstance().usesSharpFontTexture = true;
+    }
+
+    /**
+     * Disables sharp (nearest) font rendering, and uses linear font rendering instead.
+     */
+    public static void disableSharpFont() {
+        getInstance().usesSharpFontTexture = false;
     }
 
     private String tryLoadFromClasspath(final String fullLibName) {
@@ -145,6 +164,7 @@ public class ImGuiMC {
         ImGui.updatePlatformWindows();
         ImGui.renderPlatformWindowsDefault();
         GLFW.glfwMakeContextCurrent(Minecraft.getInstance().getWindow().getWindow());
+        disableSharpFont();
     }
 
     private static boolean isGone;

--- a/src/main/java/net/irisshaders/imgui/window/ImGuiImplGl3.java
+++ b/src/main/java/net/irisshaders/imgui/window/ImGuiImplGl3.java
@@ -11,6 +11,7 @@ import imgui.flag.ImGuiBackendFlags;
 import imgui.flag.ImGuiConfigFlags;
 import imgui.flag.ImGuiViewportFlags;
 import imgui.type.ImInt;
+import net.irisshaders.imgui.ImGuiMC;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GLCapabilities;
 
@@ -56,6 +57,7 @@ import static org.lwjgl.opengl.GL32.GL_LINEAR;
 import static org.lwjgl.opengl.GL32.GL_LINK_STATUS;
 import static org.lwjgl.opengl.GL32.GL_MAJOR_VERSION;
 import static org.lwjgl.opengl.GL32.GL_MINOR_VERSION;
+import static org.lwjgl.opengl.GL32.GL_NEAREST;
 import static org.lwjgl.opengl.GL32.GL_ONE;
 import static org.lwjgl.opengl.GL32.GL_ONE_MINUS_SRC_ALPHA;
 import static org.lwjgl.opengl.GL32.GL_POLYGON_MODE;
@@ -592,12 +594,14 @@ public class ImGuiImplGl3 {
         final ImInt height = new ImInt();
         final ByteBuffer pixels = fontAtlas.getTexDataAsRGBA32(width, height);
 
+        final int texFilter = ImGuiMC.getInstance().usesSharpFont() ? GL_NEAREST : GL_LINEAR;
+
         final int[] lastTexture = new int[1];
         glGetIntegerv(GL_TEXTURE_BINDING_2D, lastTexture);
         data.fontTexture = glGenTextures();
         glBindTexture(GL_TEXTURE_2D, data.fontTexture);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texFilter);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texFilter);
         glPixelStorei(GL_UNPACK_ALIGNMENT, 4); // Not on WebGL/ES
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0); // Not on WebGL/ES
         glPixelStorei(GL_UNPACK_SKIP_ROWS, 0); // Not on WebGL/ES


### PR DESCRIPTION
Supersedes #1.

Allows for users to enable sharp fonts by calling `ImGuiMC.enableSharpFont()`, and will be disabled automatically once `ImGuiMC#draw` has been called.